### PR TITLE
Update VS Code PowerShell settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,8 @@
     "editor.defaultFormatter": "Ionide.Ionide-fsharp"
   },
 
+  "powershell.integratedConsole.showOnStartup": false,
+
   "[python]": {
     "editor.formatOnSave": true,
   },


### PR DESCRIPTION
Stop PowerShell from automatically launching the interactive terminal on startup.